### PR TITLE
adding the correct packageMenager version for netlify to see.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
   },
   "engines": {
     "pnpm": "^9.12.1"
-  }
+  },
+  "packageManager": "pnpm@9.12.1"
 }

--- a/packages/vue-component-library/package.json
+++ b/packages/vue-component-library/package.json
@@ -106,5 +106,6 @@
   },
   "engines": {
     "pnpm": "^9.12.1"
-  }
+  },
+  "packageManager": "pnpm@9.12.1"
 }


### PR DESCRIPTION
> pnpm
> Netlify supports pnpm for Node.js 16.9.0 and later.
> 
> If your site’s base directory includes a pnpm-lock.yaml file, we will run pnpm install to install the dependencies listed in your package.json.
> 
> To specify a pnpm version, you can edit your package.json file:
> 
> "packageManager": "pnpm@6.3.2"
> 
> This tells Corepack to use and download your preferred pnpm version instead of the default version that Netlify sets.